### PR TITLE
[#131975557] Optionally configure log template format

### DIFF
--- a/jobs/syslog_forwarder/spec
+++ b/jobs/syslog_forwarder/spec
@@ -81,3 +81,10 @@ properties:
   syslog.queue_checkpoint_interval:
     description: write bookkeeping information on checkpoints (every n records)
     default: 100
+
+  syslog.log_template:
+    description: |
+        Syslog log template to use when sending the messages:
+        - default: Original syslog-release format: 'deployment/jobname/job_id'
+        - metron_agent: compatible with loggregator/metron_agent format '[job=foo index=0]'
+    default: "default"

--- a/jobs/syslog_forwarder/templates/rsyslog.conf.erb
+++ b/jobs/syslog_forwarder/templates/rsyslog.conf.erb
@@ -15,6 +15,7 @@ end.else do
   syslog_transport = syslog_storer.p('syslog.transport')
 end
 
+syslog_log_template = p('syslog.log_template')
 %>
 
 $ModLoad imuxsock                      # local message reception (rsyslog uses a datagram socket)
@@ -53,7 +54,13 @@ constant(value=">")
 property(name="timestamp" dateFormat="rfc3339")
 constant(value=" <%= spec.address %> ")
 property(name="programname")
+<% if syslog_log_template == 'default' %>
 constant(value=" <%= spec.deployment %>/<%= spec.job.name %>/<%= spec.id %> ")
+<% elsif syslog_log_template == 'metron_agent' %>
+constant(value=" [job=<%= name %> index=<%= spec.index.to_i %>] ")
+<% else %>
+<% raise "only 'metron_agent' and 'default' log templates are supported (was '#{syslog_log_template}')" %>
+<% end %>
 property(name="msg")
 }
 


### PR DESCRIPTION
[#131975557 Alternate solution to configure syslog forwarding without metron agent](https://www.pivotaltracker.com/n/projects/1275640/stories/131975557)

What?
----

The `metron_agent` syslog template[1] and the `syslog-release` template[2] are not equivalent. Also, the syslog_release one does not include the index number of the VM.

Because that, when we replaced the metron_agent syslog forwarding feature with the syslog-release/syslog-forwarder, the log logstash filters to parse the logs from logsearch-for-cloudfoundry stopped working[3]

In this PR we add the optional property `syslog.log_template` to chose different template formats, and we provide the 'default' format from `syslog-release/syslog-forwarder` and the format of 'metron_agent'.

Passing a log format will allow later add additional formats like 'rfc5434', making it easier to transition between then. It will be easier to do a PR upstream too.
    
These are issues in all the related repos to start using a consistent format:

 * https://github.com/cloudfoundry/syslog-release/issues/3
 * https://github.com/cloudfoundry/loggregator/issues/134
 * https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/issues/204

[1] https://github.com/cloudfoundry/loggregator/blob/develop/jobs/metron_agent/templates/syslog_forwarder.conf.erb#L53
[2] https://github.com/cloudfoundry/syslog-release/blob/master/jobs/syslog_forwarder/templates/rsyslog.conf.erb#L56
[3] https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/blob/develop/src/logsearch-config/src/logstash-filters/snippets/platform.conf#L11-L16

Dependencies
------------

After merge, we must:
 * tag it as v7.gds1
 * build a release as: `bosh create release --with-tarball --name syslog --version 7+gds1`
 * upload the release to github
 * update https://github.com/alphagov/paas-cf/tree/bugfix/rsyslog_clean_and_parsing

how to test with  paas-cf ?
---------------------------

You can test paas-cf PR together with this https://github.com/alphagov/paas-cf/pull/585

Deploy, ssh on one box and check that the change is there.

Also, the logs should be shown in logsearch.


Optional: How to test with bosh-lite?
------------

I use  [bosh-lite](https://github.com/cloudfoundry/bosh-lite/) for development of the release.

you can follow the instructions here to install it: https://github.com/alphagov/paas-haproxy-release/pull/6

Then, use the following manifest:

```

---
name: syslog
director_uuid: fb70f16a-4d6f-41f8-bc2e-0181a03dff18

releases:
- name: syslog
  version: latest

networks:
- name: default
  subnets:
  - range: 10.244.0.0/28
    reserved: [10.244.0.1]
    static: [10.244.0.2,10.244.0.4,10.244.0.6,10.244.0.8,10.244.0.10,10.244.0.12]
    cloud_properties:
      name: random

resource_pools:
- name: default
  stemcell:
    name: bosh-warden-boshlite-ubuntu-trusty-go_agent
    version: "3262.2"
  network: default
  cloud_properties: {}

compilation:
  workers: 2
  network: default
  cloud_properties: {}

update:
  canaries: 6
  canary_watch_time: 60000
  update_watch_time: 10000-300000
  max_in_flight: 6

jobs:

- name: syslog_fwd_tcp
  templates:
  - name: syslog_forwarder
    release: syslog
    consumes:
      syslog_storer: {from: syslog_tcp}
  instances: 1
  resource_pool: default
  networks:
  - name: default
    static_ips:
    - 10.244.0.4
  properties:
    syslog:
      transport: tcp
      address: 10.244.0.6
      port: 514
      fallback_addresses:
      - transport: tcp
        port: 514
        address: 10.244.0.12

- name: syslog_fwd_relp
  templates:
  - name: syslog_forwarder
    release: syslog
    consumes:
      syslog_storer: {from: syslog_relp}
  instances: 1
  resource_pool: default
  networks:
  - name: default
    static_ips:
    - 10.244.0.2
  properties:
    syslog:
      transport: relp
      address: 10.244.0.10
      port: 514
      log_format: 'metron_agent'
      fallback_servers:
      - transport: relp
        port: 514
        address: 10.244.0.12

- name: syslog_tcp
  templates:
  - name: syslog_storer
    release: syslog
    provides:
      syslog_storer: {as: syslog_tcp}
  instances: 2
  resource_pool: default
  networks:
  - name: default
    static_ips:
    - 10.244.0.6
    - 10.244.0.8
  properties:
    syslog:
      transport: tcp

- name: syslog_relp
  templates:
  - name: syslog_storer
    release: syslog
    provides:
      syslog_storer: {as: syslog_relp}
  instances: 2
  resource_pool: default
  networks:
  - name: default
    static_ips:
    - 10.244.0.10
    - 10.244.0.12
  properties:
    syslog:
      transport: relp

properties: {}


```

Use the manifest to deploy:


```
bosh deployment manifest.yml
bosh deploy
```

In order to SSH to the bosh-lite jobs,  upload the manifest to the vagrant with:
```
cd bosh-lite
vagrant ssh -- -t tee manifest.yml < /tmp/manifest.yml
```

And ssh with:
```
vagrant ssh -- -t bosh ssh syslog_fwd_relp/0
```

You can see that the file format has been changed in `cat /etc/rsyslog.d/rsyslog.conf`

Who?

---

Anyone but @keymon