### PR TITLE
[#156996834] Add post custom config before the file exclusion

### DIFF
--- a/jobs/syslog_forwarder/templates/pre-start.erb
+++ b/jobs/syslog_forwarder/templates/pre-start.erb
@@ -32,11 +32,11 @@ rsyslogd -N1 || (echo 'Custom rule configuration invalid' && rm /etc/rsyslog.d/3
 cp $(dirname $0)/../config/syslog-release-forwarding-rules.conf /etc/rsyslog.d/35-syslog-release-forwarding-rules.conf
 chmod 0644 /etc/rsyslog.d/35-syslog-release-forwarding-rules.conf
 
+cp $(dirname $0)/../config/syslog-release-post-custom-config.conf /etc/rsyslog.d/39-syslog-release-post-custom-config.conf
+chmod 0644 /etc/rsyslog.d/39-syslog-release-post-custom-config.conf
+
 cp $(dirname $0)/../config/syslog-release-file-exclusion.conf /etc/rsyslog.d/40-syslog-release-file-exclusion.conf
 chmod 0644 /etc/rsyslog.d/40-syslog-release-file-exclusion.conf
-
-cp $(dirname $0)/../config/syslog-release-post-custom-config.conf /etc/rsyslog.d/99-syslog-release-post-custom-config.conf
-chmod 0644 /etc/rsyslog.d/99-syslog-release-post-custom-config.conf
 
 # We remove the custom config if it is not valid in the context of the rsyslog config.
 rsyslogd -N1 || (echo 'Post custom configuration invalid' && rm 99-syslog-release-post-custom-config.conf)


### PR DESCRIPTION
What?
----

In the PR #4 we added the option to add custom raw config to the
end of the rsyslog config, with the intention of configure another
log target.

But this was not working fine, as some logs were being dropped.

We must configure the post custom configuration before the file
exclusion rules, otherwise all the logs from blackbox, which
are marked as procid=rs2, will be dropped before reaching this config.

This makes sense with the property, as we want this config to
be the last one before the original default config of rsyslog,
and the 40-syslog-release-file-exclusion.conf does clean the logs for
the default rsyslog config.

How to review?
-------------

Deploy as part of https://github.com/alphagov/paas-bootstrap/pull/163,
and check that all the logs are being sent both to logit and the old
logsearch stack. Specially, check the ones sent by blackbox (e.g. rep
logs).

Who?
----

Anyone but @keymon